### PR TITLE
13 sign compare warning

### DIFF
--- a/djinni/jni/Marshal.hpp
+++ b/djinni/jni/Marshal.hpp
@@ -243,7 +243,15 @@ namespace djinni
 
         static LocalRef<JniType> fromCpp(JNIEnv* jniEnv, const CppType& c)
         {
-            assert(c.size() <= std::numeric_limits<jsize>::max());
+            // according to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html
+            //    `typedef jint jsize;`
+            // and
+            //    Java Type    Native Type     Description
+            //    int          jint            signed 32 bits
+            // therefore, casting numeric_limits<jsize>::max() to uint32_t
+            // would be valid and result in the same value, but now an
+            // unsigned type which can be compared to c.size()
+            assert(c.size() <= static_cast<uint32_t>(std::numeric_limits<jsize>::max()));
             auto j = LocalRef<jbyteArray>(jniEnv, jniEnv->NewByteArray(static_cast<jsize>(c.size())));
             jniExceptionCheck(jniEnv);
             // Using .data() on an empty vector is UB
@@ -371,7 +379,13 @@ namespace djinni
         static LocalRef<JniType> fromCpp(JNIEnv* jniEnv, const CppType& c)
         {
             const auto& data = JniClass<ListJniInfo>::get();
-            assert(c.size() <= std::numeric_limits<jint>::max());
+            // according to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html
+            //    Java Type    Native Type     Description
+            //    int          jint            signed 32 bits
+            // therefore, casting numeric_limits<jint>::max() to uint32_t
+            // would be valid and result in the same value, but now an
+            // unsigned type which can be compared to c.size()
+            assert(c.size() <= static_cast<uint32_t>(std::numeric_limits<jint>::max()));
             auto size = static_cast<jint>(c.size());
             auto j = LocalRef<jobject>(jniEnv, jniEnv->NewObject(data.clazz.get(), data.constructor, size));
             jniExceptionCheck(jniEnv);

--- a/djinni/jni/Marshal.hpp
+++ b/djinni/jni/Marshal.hpp
@@ -243,14 +243,6 @@ namespace djinni
 
         static LocalRef<JniType> fromCpp(JNIEnv* jniEnv, const CppType& c)
         {
-            // according to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html
-            //    `typedef jint jsize;`
-            // and
-            //    Java Type    Native Type     Description
-            //    int          jint            signed 32 bits
-            // therefore, casting numeric_limits<jsize>::max() to uint32_t
-            // would be valid and result in the same value, but now an
-            // unsigned type which can be compared to c.size()
             assert(c.size() <= static_cast<uint32_t>(std::numeric_limits<jsize>::max()));
             auto j = LocalRef<jbyteArray>(jniEnv, jniEnv->NewByteArray(static_cast<jsize>(c.size())));
             jniExceptionCheck(jniEnv);
@@ -379,12 +371,6 @@ namespace djinni
         static LocalRef<JniType> fromCpp(JNIEnv* jniEnv, const CppType& c)
         {
             const auto& data = JniClass<ListJniInfo>::get();
-            // according to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html
-            //    Java Type    Native Type     Description
-            //    int          jint            signed 32 bits
-            // therefore, casting numeric_limits<jint>::max() to uint32_t
-            // would be valid and result in the same value, but now an
-            // unsigned type which can be compared to c.size()
             assert(c.size() <= static_cast<uint32_t>(std::numeric_limits<jint>::max()));
             auto size = static_cast<jint>(c.size());
             auto j = LocalRef<jobject>(jniEnv, jniEnv->NewObject(data.clazz.get(), data.constructor, size));


### PR DESCRIPTION
This resolves the warning reported in #13, but perhaps that issue should remain open to track removal or replacement of the `assert` statement.

According to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html ...
```
   Java Type    Native Type     Description 
   int          jint            signed 32 bits
```
and
```
   typedef jint jsize;
```
therefore, casting `numeric_limits<jsize>::max()` (and `jint`) to `uint32_t` would be valid and result in the same value, but now an unsigned type which can be compared to `c.size()`.
