### PR TITLE
add separate option for jni main entrypoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,9 @@ endif()
 
 # JNI support
 option(DJINNI_WITH_JNI "Include the JNI support code in Djinni support library." off)
+option(DJINNI_JNI_WITH_MAIN "Include the default minimal JNI_OnLoad and JNI_OnUnload implementation in Djinni support library." on)
 if(DJINNI_WITH_JNI)
-  if(NOT DJINNI_STATIC_LIB)
+  if(DJINNI_JNI_WITH_MAIN)
     list(APPEND SRC_JNI "djinni/jni/djinni_main.cpp")
   endif()
   target_include_directories(djinni_support_lib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/djinni/jni/>")


### PR DESCRIPTION
Currently the support lib does only include default `JNI_OnLoad` & `JNI_OnUnload` implementations if the support-library itself is built as shared lib.

That does not make sense in my opinion. Given the following scenario:

The (static) support-lib is linked in a (shared) library that is loaded by JNI. This would fail because JNI cannot find `JNI_OnLoad`. I would be required to add a custom `JNI_OnLoad` Implementation.

I propose to introduce a separate option to enable/disable the inclusion of the default `JNI_OnLoad` & `JNI_OnUnload` implementations: `DJINNI_JNI_WITH_MAIN`. There is the valid use case where one would want to provide it's own entrypoint into JNI if the app does use non-Djinni JNI interfaces, but in most cases the default entry-point should work.