### PR TITLE
remove unconditional mutex include

### DIFF
--- a/djinni/proxy_cache_impl.hpp
+++ b/djinni/proxy_cache_impl.hpp
@@ -18,7 +18,6 @@
 
 #include "proxy_cache_interface.hpp"
 #include <functional>
-#include <mutex>
 #include <unordered_map>
 
 #ifdef __cplusplus_cli


### PR DESCRIPTION
`<mutex>` should only be included if not building for C++/CLI, otherwise the build fails on Visual Studio 2017.

I discovered this while working on the conanfile for conan center index. This must be an error that happened to me when migrating the C# support and it wasn't noticed because we never tried to build for Visual Studio 2017