### PR TITLE
Support C++/CLI for .NET Core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ if(DJINNI_WITH_PYTHON)
 endif()
 
 option(DJINNI_WITH_CPPCLI "Include the C++/CLI support code in Djinni support library." off)
+option(DJINNI_CPPCLI_NETCORE "Configure the C++/CLI bindings for .Net Core instead of .Net Framework." off)
 if(DJINNI_WITH_CPPCLI)
 
   if(NOT MSVC)
@@ -150,10 +151,20 @@ if(DJINNI_WITH_CPPCLI)
   target_include_directories(djinni_support_lib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/support-lib/cppcli/>")
   target_sources(djinni_support_lib PRIVATE ${SRC_CPPCLI})
   source_group("cppcli" FILES ${SRC_CPPCLI})
-  set_target_properties(djinni_support_lib PROPERTIES
-    VS_DOTNET_REFERENCES "System;System.Core"
-    COMMON_LANGUAGE_RUNTIME ""
-  )
+  if(DJINNI_CPPCLI_NETCORE)
+    set_target_properties(djinni_support_lib PROPERTIES
+      COMMON_LANGUAGE_RUNTIME "netcore"
+      DOTNET_TARGET_FRAMEWORK "netcoreapp3.1"
+      COMPILE_FLAGS "/EHa"
+      VS_GLOBAL_CLRSupport "netcore"
+      )
+  else()
+    set_target_properties(djinni_support_lib PROPERTIES
+      VS_DOTNET_REFERENCES "System;System.Core"
+      COMMON_LANGUAGE_RUNTIME ""
+    )
+  endif()
+
 
   install(
     FILES


### PR DESCRIPTION
Currently the support-lib is configured for .NET Framework if the option `DJINNI_WITH_CPPCLI` is enabled.

Microsoft is steering towards a [unified .NET implementation for all platforms](https://www.c-sharpcorner.com/article/future-of-dot-net/) with .NET (Core). To be able to use djinni together with modern technologies like [Project Reunion](https://docs.microsoft.com/en-us/windows/apps/project-reunion/) or being able to create a [Nuget-package for multiple architectures](https://docs.microsoft.com/de-de/nuget/create-packages/supporting-multiple-target-frameworks), I need to be able to compile C++/CLI for .NET Core.

Microsoft offers a [migration guide](https://docs.microsoft.com/en-us/dotnet/core/porting/cpp-cli) for this.
Sadly the migration is not as easy as expected, because C++/CLI for .NET Core does not support building static libraries. I had the pleasure to learn that MSVC does not export symbols by default when building a shared library, so they have to be manually exported with [`__declspec(dllexport)`](https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-declspec-dllexport?redirectedfrom=MSDN&view=msvc-160).

This is early WIP and I just want to inform you that I am working on this. I'll have to figure out how the `dllexport` mechanism works in the first place, this is new to me... If someone can help with it I'd be super thankful!

Tasks:

- [x] introduce option to enable .NET Core (`DJINNI_CPPCLI_NETCORE`). *This may need conceputal refinement.*
- [x] build with `-clr:netcore` instead of `-clr`.
- [x] choose `netcoreapp3.1` as target framework.
- [x] remove .NET Framework references.
- [ ] export required symbols to be able to link to a shared support-lib. *This will be the hard part.* 😞 
- [ ] extend github actions to also test-build for .NET Core


Collection of other related links regarding the topic:
- This guy helped me figure out how to configure .NET Core in CMake: https://discourse.cmake.org/t/netcoreapp3-1-project-with-cmake/2917
- `-clr:netcore` collides with `/EHs`. No idea what that means but for now `/EHa` seem to do the job: https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-160

