### PR TITLE
Disable build C++/CLI and other bindings togheter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if(DJINNI_WITH_CPPCLI)
     message(FATAL_ERROR "Enabling DJINNI_WITH_CPPCLI without MSVC is not supported")
   endif()
 
+  if(DJINNI_WITH_OBJC OR DJINNI_WITH_JNI OR DJINNI_WITH_PYTHON)
+    message(FATAL_ERROR "DJINNI_WITH_CPPCLI can not be used with other bindings enabled.")
+  endif()
+
   target_include_directories(djinni_support_lib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/support-lib/cppcli/>")
   target_sources(djinni_support_lib PRIVATE ${SRC_CPPCLI})
   source_group("cppcli" FILES ${SRC_CPPCLI})


### PR DESCRIPTION
Fail cmake if `DJINNI_WITH_CPPCLI` is enabled together with any other binding.

It is currently not supported, but might theoretically build, or at least, try to build.
Since a C++/CLI build seems to be a dot net assembly, I am not sure this will ever be supported

So it's better to fail early and explicit and not even provide the option.