### PR TITLE
Remove cast to void** as the formal parameter type should be JNIEnv**

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,18 @@ jobs:
       working-directory: build/check_install_root
       run: diff -u ../../test/jni_list.txt <(du -a | tac | awk -F ' ' '{print $2}' | sort)
 
+  build-on-ubuntu-for-jni-with-thread-attach:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: asdf-vm/actions/install@v1
+    - name: Configure cmake
+      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release
+    - name: Build release
+      run: cmake --build build --parallel $(nproc)
+    - name: Run tests
+      working-directory: build/test-suite
+      run: ctest -C Release -V
 
   build-on-ubuntu-for-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,14 +87,14 @@ jobs:
     - uses: actions/checkout@v2
     - uses: asdf-vm/actions/install@v1
     - name: Configure cmake
-      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
+      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
     - name: Build release
       run: cmake --build build --parallel $(nproc)
     - name: Run tests
       working-directory: build/test-suite
       run: ctest -C Release -V
 
-      
+
   build-on-ubuntu-for-python:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: asdf-vm/actions/install@v1
     - name: Configure cmake
-      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DJINNI_BUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
+      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DJINNI_BUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a -G Ninja
     - name: Build release
       run: cmake --build build --parallel $(nproc)
-    - name: Run tests
-      working-directory: build/test-suite
-      run: ctest -C Release -V
-
 
   build-on-ubuntu-for-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: asdf-vm/actions/install@v1
+    - uses: ashutoshvarma/setup-ninja@master
+      with:
+        version: 1.10.2
     - name: Configure cmake
       run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DJINNI_BUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a -G Ninja
     - name: Build release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: asdf-vm/actions/install@v1
     - name: Configure cmake
-      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
+      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DJINNI_BUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=${ANDROID_SDK_ROOT}/ndk/$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
     - name: Build release
       run: cmake --build build --parallel $(nproc)
     - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,21 @@ jobs:
       working-directory: build/test-suite
       run: ctest -C Release -V
 
+
+  build-on-ubuntu-for-android_arm32-with-thread-attach:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: asdf-vm/actions/install@v1
+    - name: Configure cmake
+      run: cmake -S . -B build -DDJINNI_WITH_JNI=ON -DJNI_CPP_THREAD_ATTACH=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(ls ${ANDROID_SDK_ROOT}/ndk -C1 | sort -r | head -1)/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-26 -DANDROID_NATIVE_API_LEVEL=26 -DANDROID_ABI=armeabi-v7a
+    - name: Build release
+      run: cmake --build build --parallel $(nproc)
+    - name: Run tests
+      working-directory: build/test-suite
+      run: ctest -C Release -V
+
+      
   build-on-ubuntu-for-python:
     runs-on: ubuntu-latest
     steps:

--- a/djinni/jni/djinni_support.cpp
+++ b/djinni/jni/djinni_support.cpp
@@ -75,7 +75,7 @@ JNIEnv * jniGetThreadEnv() {
     jint get_res = g_cachedJVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
     #ifdef EXPERIMENTAL_AUTO_CPP_THREAD_ATTACH
     if (get_res == JNI_EDETACHED) {
-        get_res = g_cachedJVM->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
+        get_res = g_cachedJVM->AttachCurrentThread(&env, nullptr);
         thread_local struct DetachOnExit {
             ~DetachOnExit() {
                 g_cachedJVM->DetachCurrentThread();

--- a/djinni/jni/djinni_support.cpp
+++ b/djinni/jni/djinni_support.cpp
@@ -75,7 +75,12 @@ JNIEnv * jniGetThreadEnv() {
     jint get_res = g_cachedJVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
     #ifdef EXPERIMENTAL_AUTO_CPP_THREAD_ATTACH
     if (get_res == JNI_EDETACHED) {
-        get_res = g_cachedJVM->AttachCurrentThread(&env, nullptr);
+#ifdef __ANDROID__
+    get_res = g_cachedJVM->AttachCurrentThread(&env, nullptr);
+#else
+    get_res = g_cachedJVM->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
+#endif
+
         thread_local struct DetachOnExit {
             ~DetachOnExit() {
                 g_cachedJVM->DetachCurrentThread();


### PR DESCRIPTION
A recent changed altered the call to pass the p_env parameter as a void**, which causes compilation errors as the format prototype of AttachCurrentProcess is 
```
 jint AttachCurrentThread(JNIEnv** p_env, void* thr_args)
```