### PR TITLE
Assert a non null pointer, nothing else

### DIFF
--- a/djinni/jni/djinni_support.hpp
+++ b/djinni/jni/djinni_support.hpp
@@ -320,8 +320,8 @@ template <class T> using CppProxyHandle = JniCppProxyCache::Handle<std::shared_p
 
 template <class T>
 static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
-    // assume this is a pointer, reasonable far away from 0
-    assert(static_cast<uint64_t>(handle) > 4096);
+    // assume this is a pointer pointing to something
+    assert(handle != 0);
     // Below line segfaults gcc-4.8. Using a temporary variable hides the bug.
     //const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
     const CppProxyHandle<T> *proxy_handle =


### PR DESCRIPTION
As discussed in #30, the magic number brought since some time some
problems for some people.
Please find the details in the discussion of #30, and why we switch to
this assert now.

Fixes #30, second version.