### PR TITLE
Add jni load calls only for shared library buils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ set(SRC_JNI
   "djinni/jni/Marshal.hpp"
   "djinni/jni/djinni_support.cpp"
   "djinni/jni/djinni_jni_main.hpp"
-  "djinni/jni/djinni_jni_main.cpp"
 )
 
 set(SRC_OBJC
@@ -105,6 +104,12 @@ if(DJINNI_WITH_JNI)
   set_target_properties(djinni_support_lib PROPERTIES
     POSITION_INDEPENDENT_CODE ON)
   target_include_directories(djinni_support_lib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/djinni/jni/>")
+  # if this is a dynamic lib, we must have a main function in the lib
+  if ("${DJINNI_LIBRARY_TYPE}" STREQUAL "SHARED" )
+    list(APPEND SRC_JNI "djinni/jni/djinni_jni_main.cpp")
+  elseif(NOT "${DJINNI_LIBRARY_TYPE}" STREQUAL "STATIC" AND BUILD_SHARED_LIBS)
+    list(APPEND SRC_JNI "djinni/jni/djinni_jni_main.cpp")
+  endif()
   target_sources(djinni_support_lib PRIVATE ${SRC_JNI})
   source_group("jni" FILES ${SRC_JNI})
   option (JNI_CPP_THREAD_ATTACH "Add code enabling calling from C++ thread to Java (experimental)" OFF)


### PR DESCRIPTION
This should fix #50,

If users do not define their own functions, the generator will generate
a file that needs to be inlcuded.
For an own JNI_OnLoad/JNI_OnUnload function, the generator needs to be
informed.

If the support lib is used as a dynamic lib, the JNI functions are not
optional.