### PR TITLE
Add vscode dir to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*
 .idea/
 cmake-build-debug/
 check_install_root/
+.vscode/


### PR DESCRIPTION
For reasons unknown to me, we did not have .vscode in .gitignore.
Now we have :-) 