### PR TITLE
Stop clang-format from sorting header

### DIFF
--- a/djinni/objc/DJIError.mm
+++ b/djinni/objc/DJIError.mm
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-
+// clang-format off
 #include <Foundation/Foundation.h>
 #include "DJIError.h"
 #include <exception>
+// clang-format on
 static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for this file");
 
 namespace djinni {


### PR DESCRIPTION
Re-ordering those header does lead to compile error, since DJIError.h
needs to have access to types from Foundation.

clang-format does reorder them, so this needs to be turned off.

Fixes #61