### PR TITLE
Add nlohmann json serializer for std::optional, nop serializer for time_point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,13 @@ set(SRC_CPPCLI
   "djinni/cppcli/WrapperCache.cpp"
 )
 
+set(SRC_CPP_JSON
+  "djinni/cpp/json/nlohmann/json+extension.hpp"
+)
+
 # set `DJINNI_LIBRARY_TYPE` to `STATIC` or `SHARED` to define the type of library.
 # If undefined, the type will be determined based on `BUILD_SHARED_LIBS`
-add_library(djinni_support_lib ${DJINNI_LIBRARY_TYPE} ${SRC_SHARED})
+add_library(djinni_support_lib ${DJINNI_LIBRARY_TYPE} ${SRC_SHARED} ${SRC_CPP_JSON})
 add_library(djinni-support-lib::djinni-support-lib ALIAS djinni_support_lib)
 
 source_group("" FILES ${SRC_SHARED})
@@ -69,7 +73,7 @@ install(
 )
 
 install(
-  FILES ${SRC_SHARED}
+  FILES ${SRC_SHARED} ${SRC_CPP_JSON}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/djinni/
 )
 

--- a/djinni/cpp/json/nlohmann/json+extension.hpp
+++ b/djinni/cpp/json/nlohmann/json+extension.hpp
@@ -1,0 +1,51 @@
+#ifndef JSON_EXTENSION_h
+#define JSON_EXTENSION_h
+
+#include <optional>
+#include <chrono>
+
+#include <nlohmann/json.hpp>
+
+
+namespace nlohmann {
+
+    template <typename T>
+    struct adl_serializer<std::optional<T>> {
+        static void to_json(json& j, const std::optional<T>& opt) {
+            if (opt == std::nullopt) {
+                j = nullptr;
+            } else {
+              j = *opt;
+            }
+        }
+
+        static void from_json(const json& j, std::optional<T>& opt) {
+            if (j.is_null()) {
+                opt = std::nullopt;
+            } else {
+                opt = j.get<T>();
+            }
+        }
+    };
+    
+    template <>
+    struct adl_serializer<std::chrono::system_clock::time_point> {
+        static void to_json(json& j, const std::chrono::system_clock::time_point & opt) {
+            // if (opt == std::nullopt) {
+            //     j = nullptr;
+            // } else {
+            //   j = *opt;
+            // }
+        }
+
+        static void from_json(const json& j, std::chrono::system_clock::time_point & opt) {
+            // if (j.is_null()) {
+            //     opt = std::nullopt;
+            // } else {
+            //     opt = j.get<T>();
+            // }
+        }
+    };
+}
+#endif /* JSON_EXTENSION_h */
+


### PR DESCRIPTION
Companion PR to https://github.com/cross-language-cpp/djinni-generator/pull/99 .

Addapted from hiennguyenle/finn.

I have effectively made the json support part of `SRC_SHARED` insofar as it always gets installed on all platforms. It could also be configurable, but I'm a bit loathe to add too many permutations to the build options for what is now just a single file that clients can choose to opt into if they include it and will otherwise be ignored. 

It would be nice to actually add some integration tests here, although I'm not quite sure how to best address (at least) the following points:

1. circular dependency between the generator and the support lib - generator is expecting support lib with json support and the support lib would expect json support from the generator
2. nlohmann json - how best to include? I'm generally including this with conan, but I'm not sure it's a good idea to introduce a conan dependency to the test suite.