### PR TITLE
Fix compilation on gcc 11.2

### DIFF
--- a/djinni/cwrapper/wrapper_marshal.hpp
+++ b/djinni/cwrapper/wrapper_marshal.hpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <assert.h>
 #include <optional>
+#include <memory>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
std::shared_ptr<> requires memory
