### PR TITLE
fix: CsOptional partial specialization for array

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Report cmake version
       run: cmake --version        
     - name: Configure cmake
-      run: cmake -S . -B build -DDJINNI_WITH_CPPCLI=ON -DCMAKE_INSTALL_PREFIX=build/check_install_root -DDJINNI_EXECUTABLE="$(((Get-Location).Path) -replace "\\","/")/djinni.bat" -G "Visual Studio 16 2019"
+      run: cmake -S . -B build -DDJINNI_WITH_CPPCLI=ON -DCMAKE_INSTALL_PREFIX=build/check_install_root -DDJINNI_EXECUTABLE="$(((Get-Location).Path) -replace "\\","/")/djinni.bat" -G "Visual Studio 17 2022"
     - name: Install nuget dependencies
       working-directory: build/test-suite
       run: dotnet restore DjinniCppCliTest.csproj --runtime win-x64

--- a/djinni/cppcli/Marshal.hpp
+++ b/djinni/cppcli/Marshal.hpp
@@ -149,6 +149,9 @@ template<class T>
 struct IsRef<T^> : std::true_type {};
 
 template<class T>
+struct IsRef<array<T>^> : std::true_type {};
+
+template<class T>
 struct CsOptional {
     typedef System::Nullable<T> type;
 };
@@ -157,6 +160,12 @@ template<class T>
 struct CsOptional<T^> {
     typedef T^ type;
 };
+
+template<class T>
+struct CsOptional<array<T>^> {
+    typedef array<T>^ type;
+};
+
 
 template<template<class> class OptionalType, class T>
 struct Optional {


### PR DESCRIPTION
Fix wrong matched template for `array<T>^`

This commit fixes the wrong deduced type for `CsOptional<array<T>^>`, which should be matched to `CsOptional<T^>`, but matched to `CsOptional<T>`. Same for `IsRef`.