### PR TITLE
Revert "Test pr target"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,5 @@
 name: build-all-configs
-on:
-  push:
-    branches:
-      - main
-  pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+on: [push, pull_request]
 jobs:
   build-on-osx-for-objectiveC:
     runs-on: macos-11


### PR DESCRIPTION
Reverts cross-language-cpp/djinni-support-lib#78

I know now how `pull_request_target` works, 
but I also want to explore options besides that way.

Therefore, I revert that change (maybe only for now)