### PR TITLE
Add support for custom NSException translation function

### DIFF
--- a/djinni/objc/DJIError.h
+++ b/djinni/objc/DJIError.h
@@ -16,7 +16,14 @@
 
 #pragma once
 
+#include <exception>
+
 namespace djinni {
+
+typedef NSException * (* ExceptionTranslatorFunc)(const std::exception & e);
+
+// Sets custom function to perform the translation of C++ exception to NSException
+void setCustomExceptionTranslator(ExceptionTranslatorFunc func);
 
 // Throws an exception for an unimplemented method call.
 [[noreturn]] void throwUnimplemented(const char * ctx, NSString * msg);


### PR DESCRIPTION
This PR adds support to supply a function to `DJIError` in order for perform a custom translation of C++ exceptions to `NSException` outside the library.

The reason to do this is to be able to have a better translated `NSException`, as the default translation doesn't use any named constants, just uses the message from the C++ exception for both the `NSException` name and reason. 